### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: "main"
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -21,6 +21,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/publish-from-webrtc.yml
+++ b/.github/workflows/publish-from-webrtc.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   prepare:
     name: Prepare WebRTC artifacts

--- a/.github/workflows/publish-on-cocoapods.yml
+++ b/.github/workflows/publish-on-cocoapods.yml
@@ -17,6 +17,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Publish Pods Version


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **6** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [x] CI green
- [x] Code scanning alerts close after merge
